### PR TITLE
Fix: Correct import path for useAuth after refactoring

### DIFF
--- a/frontend/src/features/auth/pages/LoginPage.jsx
+++ b/frontend/src/features/auth/pages/LoginPage.jsx
@@ -2,7 +2,7 @@
 import React, { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 // Corregido: Importamos el hook personalizado useAuth
-import { useAuth } from "../../../shared/contexts/AuthContext";
+import { useAuth } from "../../../shared/contexts/authHooks"; // Path updated
 import LoginForm from "../components/LoginForm";
 import "../css/Auth.css";
 import "../css/LoginStyles.css";

--- a/frontend/src/shared/components/auth/PrivateRoute.jsx
+++ b/frontend/src/shared/components/auth/PrivateRoute.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 // Corregido: Importamos nuestro hook personalizado
-import { useAuth } from '../../contexts/AuthContext';
+import { useAuth } from '../../contexts/authHooks'; // Path updated
 
 // El componente ahora es más simple y se enfoca solo en los permisos.
 const PrivateRoute = ({ requiredPermission }) => {

--- a/frontend/src/shared/components/layout/NavbarAdmin.jsx
+++ b/frontend/src/shared/components/layout/NavbarAdmin.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useCallback } from 'react'; // useCallback imported
 import { Link, useNavigate } from 'react-router-dom';
-import { useAuth } from '../../contexts/AuthContext';
+import { useAuth } from '../../contexts/authHooks'; // Updated import path
 import {
   FaUserCircle, FaRandom, FaUsers, FaClipboardList,
   FaChartLine, FaSignOutAlt, FaCalendarCheck, FaShoppingCart,


### PR DESCRIPTION
I've fixed a runtime error (`Uncaught SyntaxError: The requested module '/src/shared/contexts/AuthContext.jsx' does not provide an export named 'useAuth'`) that was occurring after the refactoring of the contexts.

The `useAuth` hook was moved from `AuthContext.jsx` to `authHooks.js`. This update ensures all imports of `useAuth` now point to the new correct location (`frontend/src/shared/contexts/authHooks.js`).

Affected files:
- `frontend/src/shared/components/layout/NavbarAdmin.jsx`
- `frontend/src/features/auth/pages/LoginPage.jsx`
- `frontend/src/shared/components/auth/PrivateRoute.jsx`

Additionally, I verified that the imports for `CartContext` (which was moved to `cartContextValue.js`) were correct and didn't need further changes.

I ran ESLint to confirm there are no new linting issues.