### PR TITLE
Fix: Corregir todas las rutas de importación para useAuth

### DIFF
--- a/frontend/src/features/auth/pages/RegisterPage.jsx
+++ b/frontend/src/features/auth/pages/RegisterPage.jsx
@@ -2,7 +2,7 @@
 import React, { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import RegisterForm from "../components/RegisterForm";
-import { useAuth } from "../../../shared/contexts/AuthContext";
+import { useAuth } from "../../../shared/contexts/authHooks"; // Path updated
 import { registerAPI } from "../services/authService";
 import "../css/Auth.css";
 

--- a/frontend/src/features/compras/pages/FormCompraPage.jsx
+++ b/frontend/src/features/compras/pages/FormCompraPage.jsx
@@ -8,7 +8,7 @@ import ConfirmModal from '../../../shared/components/common/ConfirmModal';
 import { comprasService } from '../services/comprasService';
 import { proveedoresService } from '../../proveedores/services/proveedoresService';
 import { productosAdminService } from '../../productosAdmin/services/productosAdminService';
-import { useAuth } from '../../../shared/contexts/AuthContext';
+import { useAuth } from '../../../shared/contexts/authHooks'; // Path updated
 import '../css/FormCompra.css';
 
 function FormCompraPage() {

--- a/frontend/src/shared/components/layout/Navbar.jsx
+++ b/frontend/src/shared/components/layout/Navbar.jsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
 // Corregido: Importamos el hook personalizado useAuth
-import { useAuth } from "../../contexts/AuthContext";
+import { useAuth } from "../../contexts/authHooks"; // Path updated
 import "./Navbar.css";
 
 function Navbar() {


### PR DESCRIPTION
Este commit finaliza la corrección de las rutas de importación para el hook \`useAuth\`, que fue movido de \`AuthContext.jsx\` a \`authHooks.js\` durante una refactorización previa de los contextos.

Identifiqué y corregí las siguientes importaciones incorrectas de \`useAuth\`:
- \`frontend/src/shared/components/layout/NavbarAdmin.jsx\`
- \`frontend/src/features/auth/pages/LoginPage.jsx\`
- \`frontend/src/shared/components/auth/PrivateRoute.jsx\`
- \`frontend/src/shared/components/layout/Navbar.jsx\` (Corregido tras tu feedback adicional)
- \`frontend/src/features/compras/pages/FormCompraPage.jsx\` (Encontrado tras una búsqueda exhaustiva)
- \`frontend/src/features/auth/pages/RegisterPage.jsx\` (Encontrado tras una búsqueda exhaustiva)

Todas las importaciones de \`useAuth\` ahora apuntan consistentemente a \`frontend/src/shared/contexts/authHooks.js\`.

Ejecuté ESLint después de cada conjunto de cambios para confirmar que no hay nuevos problemas de linting. El codebase del frontend está ahora limpio según la configuración de ESLint.