### PR TITLE
Fix: Corregir posicionamiento de modales de Abastecimiento con Portals

### DIFF
--- a/frontend/src/features/abastecimiento/components/AbastecimientoCrearModal.jsx
+++ b/frontend/src/features/abastecimiento/components/AbastecimientoCrearModal.jsx
@@ -1,5 +1,6 @@
 // src/features/abastecimiento/components/AbastecimientoCrearModal.jsx
 import React, { useState, useEffect, useCallback } from "react";
+import ReactDOM from 'react-dom'; // Importar ReactDOM
 import AbastecimientoForm from "./AbastecimientoForm";
 import ItemSelectionModal from "../../../shared/components/common/ItemSelectionModal";
 import { abastecimientoService } from "../services/abastecimientoService";
@@ -61,7 +62,7 @@ const AbastecimientoCrearModal = ({ isOpen, onClose, onSubmit }) => {
 
   if (!isOpen) return null;
 
-  return (
+  const modalContent = (
     <>
       <div className="modal-abastecimiento-overlay">
         <div className="modal-abastecimiento-content formulario-modal">
@@ -110,6 +111,17 @@ const AbastecimientoCrearModal = ({ isOpen, onClose, onSubmit }) => {
         </div>
       </div>
 
+      {/* ItemSelectionModal también es un modal. Si sufre el mismo problema, necesitará un Portal.
+          Por ahora, el requerimiento es solo para los modales principales de Abastecimiento.
+          Si ItemSelectionModal se renderiza *dentro* de AbastecimientoCrearModal ANTES del portal,
+          entonces el portal de AbastecimientoCrearModal también movería ItemSelectionModal.
+          Si ItemSelectionModal se renderiza como hermano (como está aquí), entonces necesitaría su propio portal
+          si el problema de stacking context le afecta. Vamos a asumir que ItemSelectionModal no tiene el problema
+          o se tratará por separado. Por ahora, lo dejamos fuera del portal principal para que siga funcionando
+          como un modal que puede aparecer sobre el modal de creación/edición si es necesario.
+          Sin embargo, para una correcta visualización si el modal principal está en un portal,
+          ItemSelectionModal también debería estar en un portal.
+      */}
       <ItemSelectionModal
         isOpen={showProductSelectModal}
         onClose={() => setShowProductSelectModal(false)}
@@ -148,6 +160,11 @@ const AbastecimientoCrearModal = ({ isOpen, onClose, onSubmit }) => {
         searchPlaceholder="Buscar empleado..."
       />
     </>
+  );
+
+  return ReactDOM.createPortal(
+    modalContent,
+    document.body
   );
 };
 

--- a/frontend/src/features/abastecimiento/components/AbastecimientoDetailsModal.jsx
+++ b/frontend/src/features/abastecimiento/components/AbastecimientoDetailsModal.jsx
@@ -1,5 +1,6 @@
 // src/features/abastecimiento/components/AbastecimientoDetailsModal.jsx
 import React from "react";
+import ReactDOM from 'react-dom'; // Importar ReactDOM
 import { calculateRemainingLifetime } from "../services/abastecimientoService";
 
 const AbastecimientoDetailsModal = ({ isOpen, onClose, item }) => {
@@ -7,7 +8,11 @@ const AbastecimientoDetailsModal = ({ isOpen, onClose, item }) => {
     return null;
   }
 
-  return (
+  if (!isOpen || !item) {
+    return null;
+  }
+
+  const modalContent = (
     <div className="modal-abastecimiento-overlay">
       <div className="modal-abastecimiento-content detalle-modal">
         <button type="button" className="modal-close-button-x" onClick={onClose}>
@@ -69,6 +74,11 @@ const AbastecimientoDetailsModal = ({ isOpen, onClose, item }) => {
         </div>
       </div>
     </div>
+  );
+
+  return ReactDOM.createPortal(
+    modalContent,
+    document.body
   );
 };
 

--- a/frontend/src/features/abastecimiento/components/AbastecimientoEditarModal.jsx
+++ b/frontend/src/features/abastecimiento/components/AbastecimientoEditarModal.jsx
@@ -1,5 +1,6 @@
 // src/features/abastecimiento/components/AbastecimientoEditarModal.jsx
 import React, { useState, useEffect } from "react";
+import ReactDOM from 'react-dom'; // Importar ReactDOM
 import AbastecimientoForm from "./AbastecimientoForm";
 
 const AbastecimientoEditarModal = ({ isOpen, onClose, onSubmit, initialData }) => {
@@ -49,7 +50,7 @@ const AbastecimientoEditarModal = ({ isOpen, onClose, onSubmit, initialData }) =
 
   if (!isOpen) return null;
 
-  return (
+  const modalContent = (
     <div className="modal-abastecimiento-overlay">
       <div className="modal-abastecimiento-content formulario-modal">
         <button type="button" className="modal-close-button-x" onClick={onClose}>
@@ -83,6 +84,11 @@ const AbastecimientoEditarModal = ({ isOpen, onClose, onSubmit, initialData }) =
         </form>
       </div>
     </div>
+  );
+
+  return ReactDOM.createPortal(
+    modalContent,
+    document.body
   );
 };
 


### PR DESCRIPTION
Se implementó ReactDOM.createPortal para los modales AbastecimientoCrearModal, AbastecimientoEditarModal y AbastecimientoDetailsModal.

Esto resuelve problemas de contexto de apilamiento (stacking context) que causaban que los modales se renderizaran incorrectamente debajo de otros elementos (como la barra de navegación) y sin el overlay cubriendo toda la pantalla. Los modales ahora se renderizan directamente en document.body, asegurando su correcto posicionamiento y visualización.