### PR TITLE
Fix: Asegurar iconos únicos y correctos para todos los módulos de roles

### DIFF
--- a/frontend/src/features/roles/components/RolesTable.jsx
+++ b/frontend/src/features/roles/components/RolesTable.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import {
   FaEdit, FaTrash, FaEye, FaUsers, FaUserShield, FaBoxOpen, FaChartBar,
   FaUserFriends, FaCalendarAlt, FaConciergeBell, FaTags, FaShoppingCart,
-  FaTruckLoading, FaStore, FaListAlt, FaUserTie, FaNewspaper, FaHome, FaQuestionCircle, FaArchive
+  FaTruckLoading, FaStore, FaListAlt, FaUserTie, FaNewspaper, FaHome, FaQuestionCircle, FaArchive,
+  FaStar, FaShoppingBag, FaClipboardCheck, FaFolderOpen, FaWrench
 } from 'react-icons/fa';
 import Tooltip from '../../../shared/components/common/Tooltip'; // Importar el componente Tooltip
 import '../css/RolesTableExtensions.css'; // CSS adicional para los íconos de permisos
@@ -27,7 +28,15 @@ const moduloIconMap = {
   EMPLEADOS: { icon: FaUserTie, name: 'Empleados' },
   NOVEDADES: { icon: FaNewspaper, name: 'Novedades' },
   HOME: { icon: FaHome, name: 'Home' },
-  // Añadir más módulos según sea necesario
+  // Nuevos módulos y correcciones basadas en la retroalimentación del usuario
+  ESPECIALIDADES: { icon: FaStar, name: 'Especialidades' },
+  PRODUCTOS: { icon: FaShoppingBag, name: 'Productos' }, // Diferente de PRODUCTOSADMIN
+  ESTADOS: { icon: FaClipboardCheck, name: 'Estados' },
+  PERMISOS: { icon: FaUserShield, name: 'Permisos (Roles)' }, // Mapea a Roles si la clave es PERMISOS
+  CATEGORIAS: { icon: FaFolderOpen, name: 'Categorías Genéricas' }, // Para una clave genérica CATEGORIAS
+  SERVICIOS: { icon: FaWrench, name: 'Servicios' }, // Diferente de SERVICIOSADMIN
+  ABAST: { icon: FaBoxOpen, name: 'Abastecimiento (Alt.)' }, // Alias para ABASTECIMIENTO si la clave es ABAST
+  // Mantener los existentes y añadir más módulos según sea necesario
 };
 
 const RolesTable = ({ roles, onView, onEdit, onDeleteConfirm, onToggleAnular }) => {


### PR DESCRIPTION
Se realizó una revisión exhaustiva del mapeo de iconos en RolesTable.jsx para abordar el problema de múltiples módulos que mostraban el icono por defecto (FaQuestionCircle).

Cambios principales:
- Se añadieron nuevas entradas al `moduloIconMap` para módulos que no tenían un mapeo directo o cuyas claves inferidas no coincidían con las existentes. Esto incluye:
    - ESPECIALIDADES (FaStar)
    - PRODUCTOS (FaShoppingBag) - distinto de PRODUCTOSADMIN
    - ESTADOS (FaClipboardCheck)
    - PERMISOS (FaUserShield) - mapeado a Roles
    - CATEGORIAS (FaFolderOpen) - para claves genéricas
    - SERVICIOS (FaWrench) - distinto de SERVICIOSADMIN
    - ABAST (FaBoxOpen) - como alias para ABASTECIMIENTO
- Se importaron los nuevos iconos necesarios de `react-icons/fa` (FaStar, FaShoppingBag, FaClipboardCheck, FaFolderOpen, FaWrench).
- Se verificó que la lógica de extracción y búsqueda de claves de módulo sea consistente (uso de claves en mayúsculas para `moduloIconMap`).

El objetivo es que cada módulo de permiso tenga un icono representativo y se eviten los iconos por defecto, mejorando la interfaz de usuario en la gestión de roles.