### PR TITLE
Refactor: Añadir alias ABAS para icono de Abastecimiento

### DIFF
--- a/frontend/src/features/roles/components/RolesTable.jsx
+++ b/frontend/src/features/roles/components/RolesTable.jsx
@@ -36,6 +36,7 @@ const moduloIconMap = {
   CATEGORIAS: { icon: FaFolderOpen, name: 'Categorías Genéricas' }, // Para una clave genérica CATEGORIAS
   SERVICIOS: { icon: FaWrench, name: 'Servicios' }, // Diferente de SERVICIOSADMIN
   ABAST: { icon: FaBoxOpen, name: 'Abastecimiento (Alt.)' }, // Alias para ABASTECIMIENTO si la clave es ABAST
+  ABAS: { icon: FaBoxOpen, name: 'Abastecimiento (Abv.)' }, // Otra posible abreviatura para Abastecimiento
   // Mantener los existentes y añadir más módulos según sea necesario
 };
 


### PR DESCRIPTION
Se añade la clave `ABAS` al `moduloIconMap` como otra posible abreviatura para el módulo de Abastecimiento, utilizando el mismo icono `FaBoxOpen`.

Esto es un intento adicional para asegurar que el módulo de Abastecimiento muestre su icono correctamente si la clave del permiso utiliza esta abreviatura.