### PR TITLE
Fix: Aplicar layout de 4 columnas definitivo a .rol-permisos-grid

### DIFF
--- a/frontend/src/features/roles/css/Rol.css
+++ b/frontend/src/features/roles/css/Rol.css
@@ -984,45 +984,47 @@ input:checked+.slider:before {
     }
 }
 
-/* --- INICIO REQUERIMIENTO 1: Layout de Columnas en Permisos --- */
-.rol-permisos-grid {
-    display: grid;
-    gap: 10px; /* Espacio entre los items de permisos */
-    padding: 15px; /* Añadido para consistencia con el diseño del acordeón */
-    border-top: 1px solid #e0e0e0; /* Añadido para consistencia */
-    background-color: white; /* Añadido para consistencia */
-    border-bottom-left-radius: 8px; /* Añadido para consistencia */
-    border-bottom-right-radius: 8px; /* Añadido para consistencia */
+/* --- INICIO SOLUCIÓN DEFINITIVA: Layout de Columnas en Permisos --- */
 
-    /* Móvil: 1 columna por defecto, se puede ajustar a 2 si el contenido es corto */
-    grid-template-columns: repeat(1, 1fr);
+/* Asegurar que el contenedor del acordeón ocupe el ancho necesario */
+.rol-modalContent-form .rol-modulo-acordeon {
+    display: block; /* Asegura que <details> se comporte como un bloque */
+    width: 100%;   /* Ocupa todo el ancho disponible */
 }
 
-.rol-permisos-grid .rol-moduloItem {
-    /* Aseguramos que los items se comporten bien dentro del grid */
+/* Estilos para el grid de permisos con mayor especificidad */
+.rol-modalContent-form .rol-permisos-grid {
+    display: grid !important; /* Forzar display grid */
+    gap: 10px;
+    padding: 15px;
+    border-top: 1px solid #e0e0e0;
+    background-color: white;
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+    box-sizing: border-box; /* Incluir padding y border en el tamaño total */
+
+    /* Móvil: 1 columna */
+    grid-template-columns: repeat(1, 1fr) !important; /* Forzar 1 columna */
+}
+
+.rol-modalContent-form .rol-permisos-grid .rol-moduloItem {
     display: flex;
     align-items: center;
-    /* Podrías añadir más estilos específicos para el item si es necesario */
+    min-width: 0; /* Permite que los items se encojan si es necesario en el grid */
 }
 
 /* Tablet: 2 columnas */
-@media (min-width: 600px) { /* Ajusta este breakpoint según tu diseño (e.g., 768px) */
-    .rol-permisos-grid {
-        grid-template-columns: repeat(2, 1fr);
-    }
-}
-
-/* Tablet ancha / Desktop pequeño: 3 columnas */
-@media (min-width: 900px) { /* Ajusta este breakpoint según tu diseño */
-    .rol-permisos-grid {
-        grid-template-columns: repeat(3, 1fr);
+@media (min-width: 768px) { /* Ajustado breakpoint de tablet común */
+    .rol-modalContent-form .rol-permisos-grid {
+        grid-template-columns: repeat(2, 1fr) !important; /* Forzar 2 columnas */
     }
 }
 
 /* Desktop: 4 columnas */
-@media (min-width: 1200px) { /* Ajusta este breakpoint según tu diseño */
-    .rol-permisos-grid {
-        grid-template-columns: repeat(4, 1fr);
+@media (min-width: 1024px) { /* Ajustado breakpoint de desktop común */
+    .rol-modalContent-form .rol-permisos-grid {
+        grid-template-columns: repeat(4, 1fr) !important; /* Forzar 4 columnas */
     }
 }
-/* --- FIN REQUERIMIENTO 1 --- */
+
+/* --- FIN SOLUCIÓN DEFINITIVA --- */


### PR DESCRIPTION
- Reemplazado el CSS para .rol-permisos-grid con una solución más específica y robusta para asegurar el layout de 4 columnas en desktop, 2 en tablet y 1 en móvil.
- Utilizados selectores con mayor especificidad y !important para garantizar la prevalencia de las reglas de layout.
- Añadidos estilos para el contenedor <details> (.rol-modulo-acordeon) para asegurar que ocupe el ancho completo.
- Incluido box-sizing: border-box y min-width: 0 para mejorar la robustez del grid.