### PR TITLE
Fix: Corregir error de sintaxis en PermisosSelector.jsx

### DIFF
--- a/frontend/src/features/roles/components/PermisosSelector.jsx
+++ b/frontend/src/features/roles/components/PermisosSelector.jsx
@@ -79,7 +79,6 @@ const PermisosSelector = ({
                 ))}
               </div>
             </details>
-            // --- FIN DE MODIFICACIÓN ---
           ))
         ) : (
           <p>No hay permisos disponibles para asignar.</p>


### PR DESCRIPTION
Eliminado un comentario mal ubicado que causaba un error de pre-transformación en Vite.