### PR TITLE
feat(usuarios): Reemplaza filtro de estado select por interruptor

### DIFF
--- a/frontend/src/features/usuarios/css/Usuarios.css
+++ b/frontend/src/features/usuarios/css/Usuarios.css
@@ -42,6 +42,24 @@
     box-sizing: border-box;
   }
   
+  .usuarios-filtro-estado {
+    display: flex;
+    align-items: center;
+    gap: 8px; /* Espacio entre "Estado:", el switch, y la etiqueta "Activos/Inactivos" */
+    margin-right: 15px; /* Espacio a la derecha del grupo de filtro */
+  }
+
+  .usuarios-filtro-estado > span:first-child { /* "Estado:" */
+    font-size: 0.95rem;
+    color: #333;
+  }
+
+  .switch-label {
+    font-size: 0.95rem;
+    color: #333;
+    user-select: none; /* Para que el texto no sea seleccionable, común en etiquetas de controles */
+  }
+
   .usuarios-barraBusqueda {
     flex-grow: 1;
     min-width: 250px;

--- a/frontend/src/features/usuarios/hooks/useUsuarios.js
+++ b/frontend/src/features/usuarios/hooks/useUsuarios.js
@@ -28,7 +28,7 @@ const useUsuarios = () => {
   // --- Estados para Búsqueda y Filtrado (Requerimiento 3) ---
   const [inputValue, setInputValue] = useState(""); // Para el input de búsqueda inmediato
   const [searchTerm, setSearchTerm] = useState(""); // Para el término de búsqueda "debounced"
-  const [filterEstado, setFilterEstado] = useState("todos"); // 'todos', 'activos', 'inactivos'
+  const [filterEstado, setFilterEstado] = useState("activos"); // 'activos', 'inactivos' (Default 'activos')
 
   // --- Estados para la Paginación ---
   const [currentPage, setCurrentPage] = useState(1);

--- a/frontend/src/features/usuarios/pages/ListaUsuariosPage.jsx
+++ b/frontend/src/features/usuarios/pages/ListaUsuariosPage.jsx
@@ -70,18 +70,18 @@ function ListaUsuariosPage() {
             disabled={isLoadingPage} // Deshabilitar si la página está cargando datos iniciales
           />
           <div className="usuarios-filtro-estado">
-            <span>Filtrar por estado: </span>
-            <select value={filterEstado} onChange={(e) => setFilterEstado(e.target.value)} disabled={isLoadingPage}>
-              <option value="todos">Todos</option>
-              <option value="activos">Activos</option>
-              <option value="inactivos">Inactivos</option>
-            </select>
+            <span>Estado: </span>
+            <label className="switch">
+              <input
+                type="checkbox"
+                checked={filterEstado === "activos"}
+                onChange={(e) => setFilterEstado(e.target.checked ? "activos" : "inactivos")}
+                disabled={isLoadingPage}
+              />
+              <span className="slider"></span>
+            </label>
+            <span className="switch-label">{filterEstado === "activos" ? "Activos" : "Inactivos"}</span>
           </div>
-          {/* <select value={filterEstado} onChange={(e) => setFilterEstado(e.target.value)}>
-            <option value="todos">Todos</option>
-            <option value="activos">Activos</option>
-            <option value="inactivos">Inactivos</option>
-          </select> */}
           <button
             className="usuarios-botonAgregar"
             onClick={() => handleOpenModal("create")}


### PR DESCRIPTION
Reemplaza el componente <select> para el filtro de estado en la página de gestión de usuarios por un interruptor de palanca (toggle switch).

Este cambio actualiza la interfaz de usuario para filtrar usuarios por estado (activos/inactivos) utilizando un control de interruptor en lugar de un menú desplegable.

- Modificado `ListaUsuariosPage.jsx` para incluir el nuevo HTML del interruptor.
- Ajustado `useUsuarios.js` para que el estado inicial del filtro sea 'activos'.
- Utilizados y añadidos estilos CSS en `Usuarios.css` para el interruptor.