### PR TITLE
Fix(abastecimiento): Corregir datos en selección de items para modales

### DIFF
--- a/frontend/src/features/abastecimiento/components/ItemSelectionModal.jsx
+++ b/frontend/src/features/abastecimiento/components/ItemSelectionModal.jsx
@@ -37,7 +37,8 @@ const ItemSelectionModal = ({
               const label = typeof item === 'object' ? item.label : item;
               return (
                 <li key={typeof item === 'object' ? item.value : index}>
-                  <button onClick={() => { onSelectItem(value); onClose(); }}>
+                  {/* Corregido: Pasar el objeto 'item' completo en lugar de solo 'value' */}
+                  <button onClick={() => { onSelectItem(item); onClose(); }}>
                     {label}
                   </button>
                 </li>

--- a/frontend/src/features/abastecimiento/services/abastecimientoService.js
+++ b/frontend/src/features/abastecimiento/services/abastecimientoService.js
@@ -147,4 +147,19 @@ export const abastecimientoService = {
   deleteAbastecimiento,
   getProductosActivosUsoInterno,
   getEmpleadosActivos,
+  agotarAbastecimiento, // Exportar la nueva función
+};
+
+// Nueva función para marcar un producto como agotado
+const agotarAbastecimiento = async (id, razon) => {
+  try {
+    // Asegurarse de enviar 'razon_agotamiento' como espera el backend
+    const response = await apiClient.patch(`/abastecimientos/${id}/agotar`, { razon_agotamiento: razon });
+    return response.data;
+  } catch (error) {
+    throw (
+      error.response?.data ||
+      new Error("Error al marcar el producto como agotado.")
+    );
+  }
 };


### PR DESCRIPTION
- Modificar `ItemSelectionModal.jsx` para que la prop `onSelectItem` devuelva el objeto `item` completo ({label, value}) en lugar de solo `value`.
- Esto asegura que el componente padre (ej. `AbastecimientoCrearModal`) reciba los datos esperados para actualizar su estado correctamente (tanto el ID como el nombre del ítem seleccionado).
- Aborda el problema donde la selección en el modal no se reflejaba adecuadamente en el formulario principal debido a esta inconsistencia de datos.