### PR TITLE
Refactor: Implement Unified User Notifications and Secure Delete

### DIFF
--- a/frontend/src/shared/src_api/controllers/usuario.controller.js
+++ b/frontend/src/shared/src_api/controllers/usuario.controller.js
@@ -85,20 +85,19 @@ const actualizarUsuario = async (req, res, next) => {
 };
 
 /**
- * Cambia el estado (activo/inactivo) de un usuario.
+ * Cambia/ alterna el estado (activo <-> inactivo) de un usuario.
+ * Este controlador corresponde a la ruta PATCH /:idUsuario/toggle-estado
  */
-const cambiarEstadoUsuario = async (req, res, next) => {
+const toggleUsuarioEstado = async (req, res, next) => {
   try {
     const { idUsuario } = req.params;
-    const { estado } = req.body; // Se espera un booleano
-
-    const usuarioActualizado = await usuarioService.cambiarEstadoUsuario(
-      Number(idUsuario),
-      estado
+    // El servicio toggleUsuarioEstado ahora infiere el nuevo estado.
+    const usuarioActualizado = await usuarioService.toggleUsuarioEstado(
+      Number(idUsuario)
     );
     res.status(200).json({
       success: true,
-      message: `Estado del usuario ID ${idUsuario} cambiado a ${estado} exitosamente.`,
+      message: `Estado del usuario ID ${idUsuario} cambiado a ${usuarioActualizado.estado} exitosamente.`,
       data: usuarioActualizado,
     });
   } catch (error) {
@@ -107,38 +106,17 @@ const cambiarEstadoUsuario = async (req, res, next) => {
 };
 
 /**
- * Anula un usuario (borrado lógico, estado = false).
+ * Controlador para el borrado lógico (desactivar y bloquear cuenta).
+ * Este controlador corresponde a la ruta PATCH /:idUsuario/desactivar
  */
-const anularUsuario = async (req, res, next) => {
+const desactivarUsuario = async (req, res, next) => {
   try {
+    const { id } = req.params; // La ruta usa :id, pero el servicio espera un número.
+                               // Corregido en rutas a :idUsuario para consistencia.
+                               // Si la ruta realmente usa :id, aquí sería req.params.id
     const { idUsuario } = req.params;
-    const usuarioAnulado = await usuarioService.anularUsuario(
-      Number(idUsuario)
-    );
-    res.status(200).json({
-      success: true,
-      message: "Usuario anulado (deshabilitado) exitosamente.",
-      data: usuarioAnulado,
-    });
-  } catch (error) {
-    next(error);
-  }
-};
-
-/**
- * Habilita un usuario (estado = true).
- */
-const habilitarUsuario = async (req, res, next) => {
-  try {
-    const { idUsuario } = req.params;
-    const usuarioHabilitado = await usuarioService.habilitarUsuario(
-      Number(idUsuario)
-    );
-    res.status(200).json({
-      success: true,
-      message: "Usuario habilitado exitosamente.",
-      data: usuarioHabilitado,
-    });
+    await usuarioService.desactivarYBloquearUsuario(Number(idUsuario));
+    res.status(200).json({ message: 'Usuario desactivado y bloqueado exitosamente.' });
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
This commit introduces a major refactor to the user management module:

Backend (src_api):
- Modified `usuario.service.js`:
  - `toggleUsuarioEstado`: Now only toggles active/inactive status without affecting the password. Associated profiles (Cliente/Empleado) are also toggled.
  - `desactivarYBloquearUsuario`: New service for soft delete. Sets user state to inactive and nullifies the password. Prevents action on 'Administrador'.
  - `eliminarUsuarioFisico`: Revised for hard delete. Ensures associated Cliente/Empleado profiles are deleted first. Prevents action on 'Administrador'.
- Updated `usuario.routes.js`:
  - Added `PATCH /:idUsuario/desactivar` endpoint for soft delete, protected by `checkPermission(PERMISO_MODULO_USUARIOS)`.
  - Changed `DELETE /:idUsuario` (hard delete) to be protected by `checkPermission(PERMISO_MODULO_USUARIOS)` instead of `checkRole(['Administrador'])`.
  - Updated `PATCH /:idUsuario/toggle-estado` for simple state toggling, protected by `checkPermission(PERMISO_MODULO_USUARIOS)`.
  - All user management routes now consistently use `checkPermission(PERMISO_MODULO_USUARIOS)`.
  - Removed old `/anular` and `/habilitar` routes.
- Updated `usuario.controller.js`:
  - Added `desactivarUsuario` controller for soft delete.
  - Added `toggleUsuarioEstado` controller for state toggling.
  - Verified `eliminarUsuarioFisico` controller.
  - Removed old controllers.

Frontend:
- Updated `usuariosService.js`:
  - `toggleUsuarioEstadoAPI` now calls `/toggle-estado` endpoint and sends no body.
  - `desactivarUsuarioAPI` created to call `/desactivar` endpoint.
  - `eliminarUsuarioFisicoAPI` created to call `/` (DELETE) endpoint for hard delete.
- Revamped `useUsuarios.js` hook:
  - Integrated new API services.
  - Added states for soft/hard delete confirmation modals.
  - Unified success messages for all CRUD operations using `ValidationModal`.
  - Implemented modal openers and confirmation handlers for soft/hard delete.
  - Updated `handleToggleEstadoUsuario` for new API and `ValidationModal` usage.
- Updated `UsuariosTable.jsx`:
  - Receives new props for soft/hard delete actions.
  - Switch uses `onToggleEstado`.
  - Added new buttons with icons for soft and hard delete.
  - Hard delete button visible only to users with appropriate permissions (as per backend, frontend shows if logged-in user is Admin).
- Updated `ListaUsuariosPage.jsx`:
  - Passes new handlers to `UsuariosTable`.
  - Implemented two `ConfirmModal` instances for soft and hard delete flows.
  - Ensures `ValidationModal` is used for feedback on all operations.

This refactoring enhances your experience with consistent notifications, improves security with a two-tier user deletion process, and standardizes permission handling for user management routes.