### PR TITLE
Fix: Reaplicar corrección para error 409 al editar proveedores

### DIFF
--- a/frontend/src/shared/src_api/models/Proveedor.model.js
+++ b/frontend/src/shared/src_api/models/Proveedor.model.js
@@ -29,6 +29,7 @@ module.exports = (sequelize, DataTypes) => {
       numeroDocumento: {
         type: DataTypes.STRING(45),
         allowNull: true,
+        unique: true, // Añadir si la BD tiene esta restricción y se desea que sea así
         field: 'numero_documento' 
       },
       nitEmpresa: {

--- a/frontend/src/shared/src_api/services/proveedor.service.js
+++ b/frontend/src/shared/src_api/services/proveedor.service.js
@@ -208,7 +208,7 @@ const actualizarProveedor = async (idProveedor, datosActualizar) => {
       const otroProveedorConNit = await db.Proveedor.findOne({
         where: {
           nitEmpresa: nitEmpresa,
-          estado: true, // Condición 1: Solo buscar en proveedores ACTIVOS
+          // estado: true, // Se elimina esta condición para que coincida con la restricción UNIQUE de la BD
           idProveedor: { [Op.ne]: idProveedor }, // Condición 2: Excluirse a SÍ MISMO
         },
       });
@@ -225,7 +225,7 @@ const actualizarProveedor = async (idProveedor, datosActualizar) => {
       const otroProveedorConCorreo = await db.Proveedor.findOne({
         where: {
           correo: correo,
-          estado: true, // Condición 1: Solo buscar en proveedores ACTIVOS
+          // estado: true, // Se elimina esta condición para que coincida con la restricción UNIQUE de la BD
           idProveedor: { [Op.ne]: idProveedor }, // Condición 2: Excluirse a SÍ MISMO
         },
       });
@@ -242,7 +242,7 @@ const actualizarProveedor = async (idProveedor, datosActualizar) => {
       const otroProveedorConDocumento = await db.Proveedor.findOne({
         where: {
           numeroDocumento: numeroDocumento,
-          estado: true, // Condición 1: Solo buscar en proveedores ACTIVOS
+          // estado: true, // Se elimina esta condición para que coincida con la restricción UNIQUE de la BD (asumiendo que existe)
           idProveedor: { [Op.ne]: idProveedor }, // Condición 2: Excluirse a SÍ MISMO
         },
       });
@@ -270,7 +270,7 @@ const actualizarProveedor = async (idProveedor, datosActualizar) => {
         where: {
           nombre: nombreFinal,
           tipo: tipoFinal,
-          estado: true, // Condición 1: Solo buscar en proveedores ACTIVOS
+          // estado: true, // Se elimina esta condición para que coincida con el índice UNIQUE de la BD
           idProveedor: { [Op.ne]: idProveedor }, // Condición 2: Excluirse a SÍ MISMO
         },
       });
@@ -416,7 +416,7 @@ const eliminarProveedorFisico = async (idProveedor) => {
  */
 const verificarDatosUnicos = async (campos, idExcluir = null) => {
     const errores = {};
-    const whereClause = { estado: true }; // <-- CORRECCIÓN
+    const whereClause = { }; // Se elimina el filtro por estado para ser consistente
     if (idExcluir) {
         whereClause.idProveedor = { [Op.ne]: idExcluir };
     }


### PR DESCRIPTION
He reaplicado los cambios para resolver inconsistencias en la validación de unicidad que causaban un error 409 al editar proveedores. Las modificaciones se centran en alinear las validaciones del servicio con las restricciones de la base de datos.

Cambios:
1. En `frontend/src/shared/src_api/services/proveedor.service.js`:
   - Eliminé el filtro `estado: true` de las consultas de validación de unicidad (para NIT, correo, número de documento y la combinación nombre/tipo) dentro de la función `actualizarProveedor`.
   - Eliminé el filtro `estado: true` de la consulta dentro de la función `verificarDatosUnicos`.
2. En `frontend/src/shared/src_api/models/Proveedor.model.js`:
   - Añadí `unique: true` al campo `numeroDocumento` para reflejar la restricción esperada por la base de datos.

Estos cambios tienen como objetivo asegurar que las validaciones en la capa de aplicación sean consistentes con las restricciones de la base de datos, previniendo el error 409 en escenarios donde no debería ocurrir.