### PR TITLE
Refactor(abastecimiento): Elimina referencias a empleados

### DIFF
--- a/frontend/src/features/abastecimiento/components/AbastecimientoTable.jsx
+++ b/frontend/src/features/abastecimiento/components/AbastecimientoTable.jsx
@@ -29,7 +29,6 @@ const AbastecimientoTable = ({
           <th>Producto</th>
           <th>Categoría</th>
           <th>Cantidad</th>
-          <th>Empleado Asignado</th>
           <th>Fecha de Ingreso</th>
           <th>Vida Restante</th>
           <th>Estado</th>
@@ -50,9 +49,6 @@ const AbastecimientoTable = ({
                 {entry.producto?.categoria?.nombre || "N/A"}
               </td>
               <td data-label="Cantidad:">{entry.cantidad}</td>
-              <td data-label="Empleado:">
-                {entry.empleado?.nombre || "No asignado"}
-              </td>
               <td data-label="Fecha Ingreso:">
                 {new Date(entry.fechaIngreso).toLocaleDateString()}
               </td>

--- a/frontend/src/features/abastecimiento/hooks/useAbastecimiento.js
+++ b/frontend/src/features/abastecimiento/hooks/useAbastecimiento.js
@@ -6,7 +6,6 @@ import {
   updateAbastecimiento,
   deleteAbastecimiento,
   getProductosActivosUsoInterno,
-  getEmpleadosActivos,
 } from "../services/abastecimientoService";
 import { toast } from "react-toastify";
 
@@ -19,7 +18,6 @@ const useAbastecimiento = () => {
   const [filters, setFilters] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [productos, setProductos] = useState([]);
-  const [empleados, setEmpleados] = useState([]);
   const [dependenciasCargadas, setDependenciasCargadas] = useState(false);
 
   const rowsPerPage = 10;
@@ -47,12 +45,8 @@ const useAbastecimiento = () => {
   const fetchDependencias = useCallback(async () => {
     try {
       setLoading(true);
-      const [productosData, empleadosData] = await Promise.all([
-        getProductosActivosUsoInterno(),
-        getEmpleadosActivos(),
-      ]);
+      const productosData = await getProductosActivosUsoInterno();
       setProductos(productosData.data);
-      setEmpleados(empleadosData.data);
       setDependenciasCargadas(true);
     } catch (err) {
       console.error(
@@ -148,7 +142,6 @@ const useAbastecimiento = () => {
     rowsPerPage,
     isSubmitting,
     productos,
-    empleados,
     dependenciasCargadas,
     handleCreateAbastecimiento,
     handleUpdateAbastecimiento,

--- a/frontend/src/features/abastecimiento/services/abastecimientoService.js
+++ b/frontend/src/features/abastecimiento/services/abastecimientoService.js
@@ -29,18 +29,6 @@ export const getProductosActivosUsoInterno = async () => {
 };
 
 /**
- * Obtiene la lista de empleados activos desde la API.
- */
-export const getEmpleadosActivos = async () => {
-  try {
-    const response = await apiClient.get("/empleados/activos");
-    return response.data.data;
-  } catch (error) {
-    throw error.response?.data || new Error("Error al obtener empleados.");
-  }
-};
-
-/**
  * Crea un nuevo registro de abastecimiento en el sistema.
  */
 export const createAbastecimiento = async (data) => {


### PR DESCRIPTION
Elimina todas las referencias a las relaciones con empleados (`id_empleado`, `empleado`) del módulo de abastecimiento en el frontend.

Esto incluye:
- Eliminar la función `getEmpleadosActivos` del servicio.
- Limpiar el hook `useAbastecimiento` para que no gestione el estado de los empleados.
- Actualizar el componente `AbastecimientoTable` para remover la columna de "Empleado Asignado".

Estos cambios son necesarios porque las relaciones correspondientes han sido eliminadas del backend.