### PR TITLE
refactor(forms): Create reusable PasswordInput component

### DIFF
--- a/frontend/src/features/clientes/components/ClienteForm.jsx
+++ b/frontend/src/features/clientes/components/ClienteForm.jsx
@@ -1,14 +1,13 @@
 // src/features/clientes/components/ClienteForm.jsx
 import React from 'react';
-import "../css/Clientes.css"; // Ruta corregida
+import "../css/Clientes.css";
+import PasswordInput from '../../../shared/components/PasswordInput/PasswordInput'; // Importar el componente reutilizable
 
-// ¡Asegúrate de que esta declaración esté aquí, fuera de la función del componente!
 const TIPOS_DOCUMENTO = ['Cédula de Ciudadanía', 'Cédula de Extranjería', 'Pasaporte', 'Tarjeta de Identidad'];
 
-const ClienteForm = ({ formData, onFormChange, isEditing, formErrors }) => { // Agregado formErrors como prop
+const ClienteForm = ({ formData, onFormChange, isEditing, formErrors }) => {
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
-    // Para checkboxes, `e.target.checked` es el valor booleano
     onFormChange(name, type === 'checkbox' ? checked : value);
   };
 
@@ -16,37 +15,35 @@ const ClienteForm = ({ formData, onFormChange, isEditing, formErrors }) => { // 
     <div className="clientes-form-grid">
       <div className="clientes-form-group">
         <label htmlFor="nombre">Nombre: <span className="required-asterisk">*</span></label>
-        <input type="text" id="nombre" name="nombre" value={formData.nombre || ''} onChange={handleChange} placeholder="Nombre" required />
+        <input type="text" id="nombre" name="nombre" value={formData.nombre || ''} onChange={handleChange} placeholder="Nombre" required className={formErrors.nombre ? "input-error" : ""} />
         {formErrors.nombre && <p className="error-message">{formErrors.nombre}</p>}
       </div>
       <div className="clientes-form-group">
         <label htmlFor="apellido">Apellido: <span className="required-asterisk">*</span></label>
-        <input type="text" id="apellido" name="apellido" value={formData.apellido || ''} onChange={handleChange} placeholder="Apellido" required />
+        <input type="text" id="apellido" name="apellido" value={formData.apellido || ''} onChange={handleChange} placeholder="Apellido" required className={formErrors.apellido ? "input-error" : ""} />
         {formErrors.apellido && <p className="error-message">{formErrors.apellido}</p>}
       </div>
 
-      {/* Campo de Correo ocupando todo el ancho */}
       <div className="clientes-form-group-full-width">
         <label htmlFor="correo">Correo: <span className="required-asterisk">*</span></label>
-        <input type="email" id="correo" name="correo" value={formData.correo || ''} onChange={handleChange} placeholder="Correo electrónico" required />
+        <input type="email" id="correo" name="correo" value={formData.correo || ''} onChange={handleChange} placeholder="Correo electrónico" required className={formErrors.correo ? "input-error" : ""} />
         {formErrors.correo && <p className="error-message">{formErrors.correo}</p>}
       </div>
 
-      {/* Campo de Dirección ocupando todo el ancho */}
       <div className="clientes-form-group-full-width">
         <label htmlFor="direccion">Dirección:</label>
-        <input type="text" id="direccion" name="direccion" value={formData.direccion || ''} onChange={handleChange} placeholder="Dirección" />
+        <input type="text" id="direccion" name="direccion" value={formData.direccion || ''} onChange={handleChange} placeholder="Dirección" className={formErrors.direccion ? "input-error" : ""} />
         {formErrors.direccion && <p className="error-message">{formErrors.direccion}</p>}
       </div>
 
       <div className="clientes-form-group">
         <label htmlFor="telefono">Teléfono: <span className="required-asterisk">*</span></label>
-        <input type="text" id="telefono" name="telefono" value={formData.telefono || ''} onChange={handleChange} placeholder="Teléfono" required />
+        <input type="text" id="telefono" name="telefono" value={formData.telefono || ''} onChange={handleChange} placeholder="Teléfono" required className={formErrors.telefono ? "input-error" : ""} />
         {formErrors.telefono && <p className="error-message">{formErrors.telefono}</p>}
       </div>
       <div className="clientes-form-group">
         <label htmlFor="tipoDocumento">Tipo de Documento: <span className="required-asterisk">*</span></label>
-        <select id="tipoDocumento" name="tipoDocumento" value={formData.tipoDocumento || ''} onChange={handleChange} required>
+        <select id="tipoDocumento" name="tipoDocumento" value={formData.tipoDocumento || ''} onChange={handleChange} required className={formErrors.tipoDocumento ? "input-error" : ""}>
           <option value="" disabled>Seleccione un tipo</option>
           {TIPOS_DOCUMENTO.map(tipo => <option key={tipo} value={tipo}>{tipo}</option>)}
         </select>
@@ -54,31 +51,41 @@ const ClienteForm = ({ formData, onFormChange, isEditing, formErrors }) => { // 
       </div>
       <div className="clientes-form-group">
         <label htmlFor="numeroDocumento">Número de Documento: <span className="required-asterisk">*</span></label>
-        <input type="text" id="numeroDocumento" name="numeroDocumento" value={formData.numeroDocumento || ''} onChange={handleChange} placeholder="Número de Documento" required />
+        <input type="text" id="numeroDocumento" name="numeroDocumento" value={formData.numeroDocumento || ''} onChange={handleChange} placeholder="Número de Documento" required className={formErrors.numeroDocumento ? "input-error" : ""} />
         {formErrors.numeroDocumento && <p className="error-message">{formErrors.numeroDocumento}</p>}
       </div>
 
       <div className="clientes-form-group">
         <label htmlFor="fechaNacimiento">Fecha de Nacimiento: <span className="required-asterisk">*</span></label>
-        <input type="date" id="fechaNacimiento" name="fechaNacimiento" value={formData.fechaNacimiento || ''} onChange={handleChange} required />
+        <input type="date" id="fechaNacimiento" name="fechaNacimiento" value={formData.fechaNacimiento || ''} onChange={handleChange} required className={formErrors.fechaNacimiento ? "input-error" : ""} />
         {formErrors.fechaNacimiento && <p className="error-message">{formErrors.fechaNacimiento}</p>}
       </div>
 
-      {/* --- SECCIÓN DE CONTRASEÑA MODIFICADA --- */}
-      {/* Solo se muestran al crear un nuevo cliente */}
       {!isEditing && (
         <>
           <div className="clientes-form-group">
-            {/* Cambiado de 'password' a 'contrasena' para coincidir con el backend */}
             <label htmlFor="contrasena">Contraseña: <span className="required-asterisk">*</span></label>
-            <input type="password" id="contrasena" name="contrasena" value={formData.contrasena || ''} onChange={handleChange} placeholder="Contraseña" required />
+            <PasswordInput
+              name="contrasena"
+              value={formData.contrasena || ''}
+              onChange={handleChange}
+              placeholder="Contraseña"
+              required
+              className={formErrors.contrasena ? "input-error" : ""}
+            />
             {formErrors.contrasena && <p className="error-message">{formErrors.contrasena}</p>}
           </div>
 
-          {/* CAMPO AGREGADO: Confirmar Contraseña (validación solo de frontend) */}
           <div className="clientes-form-group">
             <label htmlFor="confirmPassword">Confirmar Contraseña: <span className="required-asterisk">*</span></label>
-            <input type="password" id="confirmPassword" name="confirmPassword" value={formData.confirmPassword || ''} onChange={handleChange} placeholder="Confirmar Contraseña" required />
+            <PasswordInput
+              name="confirmPassword"
+              value={formData.confirmPassword || ''}
+              onChange={handleChange}
+              placeholder="Confirmar Contraseña"
+              required
+              className={formErrors.confirmPassword ? "input-error" : ""}
+            />
             {formErrors.confirmPassword && <p className="error-message">{formErrors.confirmPassword}</p>}
           </div>
         </>
@@ -91,7 +98,7 @@ const ClienteForm = ({ formData, onFormChange, isEditing, formErrors }) => { // 
             <input
               type="checkbox"
               name="estado"
-              checked={formData.estado || false} // Asegurarse que tenga un valor booleano
+              checked={formData.estado || false}
               onChange={(e) => onFormChange('estado', e.target.checked)}
             />
             <span className="slider"></span>

--- a/frontend/src/features/usuarios/components/UsuarioForm.jsx
+++ b/frontend/src/features/usuarios/components/UsuarioForm.jsx
@@ -1,17 +1,8 @@
 // src/features/usuarios/components/UsuarioForm.jsx
-import React, { useState } from 'react'; // Importamos useState
+import React from 'react';
+import PasswordInput from '../../../shared/components/PasswordInput/PasswordInput'; // Importar el componente reutilizable
 
 const RequiredAsterisk = () => <span className="required-asterisk">*</span>;
-
-// Componentes SVG para los íconos de ojo (para no usar librerías externas)
-const EyeIcon = ({ closed }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-    <circle cx="12" cy="12" r="3"></circle>
-    {closed && <line x1="1" y1="1" x2="23" y2="23"></line>}
-  </svg>
-);
-
 
 const UsuarioForm = ({
   formData,
@@ -26,11 +17,6 @@ const UsuarioForm = ({
   isUserAdmin
 }) => {
   const errors = formErrors || {};
-  
-  // --- INICIO DE MODIFICACIÓN: Estado para visibilidad de contraseñas ---
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  // --- FIN DE MODIFICACIÓN ---
 
   return (
     <div className="usuarios-form-grid-container">
@@ -75,49 +61,35 @@ const UsuarioForm = ({
 
       {!isEditing && (
         <>
-          {/* --- INICIO DE MODIFICACIÓN: Campo de contraseña con botón --- */}
+          {/* --- INICIO DE REFACTORIZACIÓN: Campo de contraseña con componente reutilizable --- */}
           <div className="usuarios-form-grid-item">
             <label htmlFor="contrasena" className="usuarios-form-label">Contraseña <RequiredAsterisk /></label>
-            <div className="password-input-wrapper">
-              <input
-                type={showPassword ? "text" : "password"}
-                id="contrasena"
-                name="contrasena"
-                autoComplete="new-password"
-                value={formData.contrasena || ""}
-                onChange={onInputChange}
-                onBlur={onInputBlur}
-                required
-                className={`usuarios-form-input ${errors.contrasena ? "input-error" : ""}`}
-              />
-              <button type="button" className="password-toggle-button" onClick={() => setShowPassword(!showPassword)}>
-                <EyeIcon closed={showPassword} />
-              </button>
-            </div>
+            <PasswordInput
+              name="contrasena"
+              value={formData.contrasena || ""}
+              onChange={onInputChange}
+              onBlur={onInputBlur}
+              placeholder="Contraseña"
+              required
+              className={`usuarios-form-input ${errors.contrasena ? "input-error" : ""}`}
+            />
             {errors.contrasena && <span className="error-message">{errors.contrasena}</span>}
           </div>
 
           <div className="usuarios-form-grid-item">
             <label htmlFor="confirmarContrasena" className="usuarios-form-label">Confirmar Contraseña <RequiredAsterisk /></label>
-            <div className="password-input-wrapper">
-              <input
-                type={showConfirmPassword ? "text" : "password"}
-                id="confirmarContrasena"
-                name="confirmarContrasena"
-                autoComplete="new-password"
-                value={formData.confirmarContrasena || ""}
-                onChange={onInputChange}
-                onBlur={onInputBlur}
-                required
-                className={`usuarios-form-input ${errors.confirmarContrasena ? "input-error" : ""}`}
-              />
-              <button type="button" className="password-toggle-button" onClick={() => setShowConfirmPassword(!showConfirmPassword)}>
-                <EyeIcon closed={showConfirmPassword} />
-              </button>
-            </div>
+            <PasswordInput
+              name="confirmarContrasena"
+              value={formData.confirmarContrasena || ""}
+              onChange={onInputChange}
+              onBlur={onInputBlur}
+              placeholder="Confirmar Contraseña"
+              required
+              className={`usuarios-form-input ${errors.confirmarContrasena ? "input-error" : ""}`}
+            />
             {errors.confirmarContrasena && <span className="error-message">{errors.confirmarContrasena}</span>}
           </div>
-          {/* --- FIN DE MODIFICACIÓN --- */}
+          {/* --- FIN DE REFACTORIZACIÓN --- */}
         </>
       )}
 
@@ -145,7 +117,6 @@ const UsuarioForm = ({
             {errors.apellido && <span className="error-message">{errors.apellido}</span>}
           </div>
           
-          {/* ... otros campos de perfil sin cambios ... */}
           <div className="usuarios-form-grid-item">
             <label htmlFor="tipoDocumento" className="usuarios-form-label">Tipo de Documento <RequiredAsterisk /></label>
             <select id="tipoDocumento" name="tipoDocumento" value={formData.tipoDocumento || ""}

--- a/frontend/src/features/usuarios/css/Usuarios.css
+++ b/frontend/src/features/usuarios/css/Usuarios.css
@@ -436,42 +436,6 @@
     transform: translateX(22px); /* width del slider - width del círculo - 2*left_del_círculo */
                                   /* ej. 44 - 16 - (2*3) = 22 */
   }
-  
-    .password-input-wrapper {
-      position: relative;
-      width: 100%;
-      display: flex;
-      align-items: center;
-    }
-  
-    /* Hacemos que el input dentro del wrapper ocupe todo el ancho */
-    .password-input-wrapper .usuarios-form-input {
-      width: 100%;
-      padding-right: 40px;
-      /* Añade espacio para el botón */
-    }
-  
-    .password-toggle-button {
-      position: absolute;
-      right: 10px;
-      /* Posición del botón dentro del wrapper */
-      top: 50%;
-      transform: translateY(-50%);
-      background-color: transparent;
-      border: none;
-      cursor: pointer;
-      padding: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: #888;
-      /* Color del ícono */
-    }
-  
-    .password-toggle-button:hover {
-      color: #333;
-      /* Color al pasar el mouse */
-    }
     
   /* === ESTILOS RESPONSIVOS === */
   @media (max-width: 1024px) { /* Breakpoint para tablets */

--- a/frontend/src/shared/components/PasswordInput/PasswordInput.css
+++ b/frontend/src/shared/components/PasswordInput/PasswordInput.css
@@ -1,0 +1,59 @@
+/*
+ * Estilos para el componente reutilizable PasswordInput.
+ * Estos estilos están pensados para ser genéricos y poder
+ * sobreescribirse si es necesario desde el componente padre.
+ */
+
+.password-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%; /* El wrapper ocupa todo el ancho disponible */
+}
+
+/*
+ * El input dentro del wrapper. Ocupa todo el ancho y tiene un padding
+ * a la derecha para dejar espacio al botón del ojo.
+ */
+.password-input-wrapper .password-input {
+  width: 100%;
+  box-sizing: border-box; /* Asegura que el padding no incremente el tamaño total */
+  /*
+   * Usamos !important para asegurarnos de que este padding prevalezca
+   * sobre otros estilos de input que puedan aplicarse globalmente.
+   * Aunque !important debe usarse con moderación, en un componente
+   * reutilizable como este, garantiza que la funcionalidad visual
+   * clave (el espacio para el ícono) no se rompa accidentalmente.
+   */
+  padding-right: 40px !important;
+}
+
+/*
+ * Botón para mostrar/ocultar la contraseña.
+ * Se posiciona de forma absoluta dentro del wrapper.
+ */
+.password-toggle-button {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #888; /* Color grisáceo para el ícono */
+  transition: color 0.2s ease;
+}
+
+.password-toggle-button:hover {
+  color: #333; /* Un color más oscuro al pasar el ratón */
+}
+
+.password-toggle-button:focus {
+  outline: none; /* Quitamos el outline por defecto */
+  /* Opcional: añadir un anillo de foco personalizado para accesibilidad */
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}

--- a/frontend/src/shared/components/PasswordInput/PasswordInput.jsx
+++ b/frontend/src/shared/components/PasswordInput/PasswordInput.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import './PasswordInput.css'; // CSS específico para este componente
+
+// El ícono se puede mantener aquí o mover a un archivo de íconos compartidos si se usa en más lugares.
+// Por ahora, lo mantenemos aquí para que el componente sea autocontenido.
+const EyeIcon = ({ closed }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+    <circle cx="12" cy="12" r="3"></circle>
+    {closed && <line x1="1" y1="1" x2="23" y2="23"></line>}
+  </svg>
+);
+
+const PasswordInput = ({
+  name,
+  value,
+  onChange,
+  onBlur,
+  placeholder,
+  autoComplete = "new-password",
+  className = "", // Permite pasar clases adicionales para personalizar
+  required = false
+}) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  // Combinamos las clases que vienen de props con las de error si es necesario
+  const inputClassName = `password-input ${className}`.trim();
+
+  return (
+    <div className="password-input-wrapper">
+      <input
+        type={showPassword ? "text" : "password"}
+        id={name}
+        name={name}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        autoComplete={autoComplete}
+        required={required}
+        className={inputClassName}
+      />
+      <button
+        type="button"
+        className="password-toggle-button"
+        onClick={() => setShowPassword(!showPassword)}
+        aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
+      >
+        <EyeIcon closed={showPassword} />
+      </button>
+    </div>
+  );
+};
+
+export default PasswordInput;


### PR DESCRIPTION
- Created a new reusable `PasswordInput` component to encapsulate the show/hide password functionality.
- Refactored `UsuarioForm` to use the new `PasswordInput` component, removing duplicated code.
- Implemented the `PasswordInput` component in `ClienteForm` to add the show/hide password feature, ensuring consistency across forms.